### PR TITLE
Actually fix IndexError

### DIFF
--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -294,7 +294,7 @@ class _HtmlTestResult(_TextTestResult):
             test_name = self._test_method_name(test.test_id)
             test_number = int(test_name.split('_')[1])
 
-        except ValueError:
+        except ValueError, IndexError:
             pass
         return test_number
 

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -294,7 +294,7 @@ class _HtmlTestResult(_TextTestResult):
             test_name = self._test_method_name(test.test_id)
             test_number = int(test_name.split('_')[1])
 
-        except ValueError, IndexError:
+        except (ValueError, IndexError) as e:
             pass
         return test_number
 


### PR DESCRIPTION
Hi @oldani thanks for merging the earlier pull request so quickly. Unfortunately using the old Python syntax `except ValueError, IndexError` results in an exception variable called `IndexError` rather than catching both types of exception. 

This code does what we want for #23