### PR TITLE
New functionality (combine reports etc)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,4 +8,4 @@
 
 ## Contributors
 
-None yet. Why not be the first?
+* James Sloan <james.m.t.sloan@gmail.com>

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -224,7 +224,7 @@ class HtmlTestResult(TextTestResult):
             for test_info in tests:
                 if isinstance(test_info, tuple):
                     test_info = test_info[0]
-                testcase_name = test_info.test_name
+                testcase_name = ".".join(test_info.test_id.split(".")[:-1])
                 if testcase_name not in tests_by_testcase:
                     tests_by_testcase[testcase_name] = []
                 tests_by_testcase[testcase_name].append(test_info)
@@ -266,7 +266,7 @@ class HtmlTestResult(TextTestResult):
         result_summary = ', '.join(status)
 
         if elapsed_time is not None:
-            result_summary += ". Duration: {}".format(self._format_duration(elapsed_time))
+            result_summary += " -- Duration: {}".format(self._format_duration(elapsed_time))
 
         return result_summary
 

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -236,7 +236,7 @@ class HtmlTestResult(TextTestResult):
             self.stream.writeln('%s' % test_info.get_error_info())
 
     def _get_info_by_testcase(self):
-        """ Organize test results  by TestCase module. """
+        """ Organize test results by TestCase module. """
 
         tests_by_testcase = {}
 
@@ -248,6 +248,10 @@ class HtmlTestResult(TextTestResult):
                 if testcase_name not in tests_by_testcase:
                     tests_by_testcase[testcase_name] = []
                 tests_by_testcase[testcase_name].append(test_info)
+
+        # unittest tests in alphabetical order based on test name so re-assert this
+        for tests in tests_by_testcase.values():
+            tests.sort(key=lambda x: x.test_id)
 
         return tests_by_testcase
 

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -237,13 +237,13 @@ class HtmlTestResult(TextTestResult):
         if elapsed_time > 1:
             duration = '{:2.2f} s'.format(elapsed_time)
         else:
-            duration = '{:2.2f} ms'.format(elapsed_time * 1000)
+            duration = '{:d} ms'.format(int(elapsed_time * 1000))
         return duration
 
-    def get_results_summary(self, tests, elapsed_time=None):
+    def get_results_summary(self, tests, elapsed_time):
         """Create a summary of the outcomes of all given tests."""
 
-        failures = errors = skips = success = 0
+        failures = errors = skips = successes = 0
         for test in tests:
             outcome = test.outcome
             if outcome == test.ERROR:
@@ -253,32 +253,25 @@ class HtmlTestResult(TextTestResult):
             elif outcome == test.SKIP:
                 skips += 1
             elif outcome == test.SUCCESS:
-                success += 1
+                successes += 1
 
-        status = ['Total: {}'.format(len(tests))]
-        if success:
-            status.append('Pass: {}'.format(success))
-        if failures:
-            status.append('Fail: {}'.format(failures))
-        if errors:
-            status.append('Error: {}'.format(errors))
-        if skips:
-            status.append('Skip: {}'.format(skips))
-        result_summary = ', '.join(status)
+        results_summary = {
+            "total": len(tests),
+            "error": errors,
+            "failure": failures,
+            "skip": skips,
+            "success": successes,
+            "duration": self._format_duration(elapsed_time)
+        }
 
-        if elapsed_time is not None:
-            result_summary += " -- Duration: {}".format(self._format_duration(elapsed_time))
-
-        return result_summary
+        return results_summary
 
     def _get_header_info(self, tests, start_time, elapsed_time):
-        result_summary = self.get_results_summary(tests)
-        duration = self._format_duration(elapsed_time)
+        results_summary = self.get_results_summary(tests, elapsed_time)
 
         header_info = {
             "start_time": start_time,
-            "duration": duration,
-            "status": result_summary
+            "status": results_summary
         }
         return header_info
 

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -251,6 +251,7 @@ class HtmlTestResult(TextTestResult):
 
         tests_by_testcase = {}
 
+        subtest_names = set(self.subtests.keys())
         for test_name, subtests in self.subtests.items():
             subtest_info = _SubTestInfos(test_name, subtests)
             testcase_name = ".".join(test_name.split(".")[:-1])
@@ -260,7 +261,10 @@ class HtmlTestResult(TextTestResult):
 
         for tests in (self.successes, self.failures, self.errors, self.skipped):
             for test_info in tests:
-                if test_info.is_subtest:
+                # subtests will be contained by _SubTestInfos objects but there is also the
+                # case where all subtests pass and the method is added as a success as well
+                # which must be filtered out
+                if test_info.is_subtest or test_info.test_id in subtest_names:
                     continue
                 if isinstance(test_info, tuple):  # TODO: does this ever occur?
                     test_info = test_info[0]
@@ -329,9 +333,6 @@ class HtmlTestResult(TextTestResult):
 
     def _get_report_summaries(self, all_results, testRunner):
         """ Generate headers and summaries for all given test cases."""
-        start_time = testRunner.start_time
-        # elapsed_time = testRunner.time_taken.total_seconds()
-
         summaries = {}
         for test_case_class_name, test_case_tests in all_results.items():
             summaries[test_case_class_name] = self.get_results_summary(test_case_tests)

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -233,6 +233,7 @@ class HtmlTestResult(TextTestResult):
 
     @staticmethod
     def _format_duration(elapsed_time):
+        """Format the elapsed time in seconds, or milliseconds if the duration is less than 1 second."""
         if elapsed_time > 1:
             duration = '{:2.2f} s'.format(elapsed_time)
         else:
@@ -240,7 +241,7 @@ class HtmlTestResult(TextTestResult):
         return duration
 
     def get_results_summary(self, tests, elapsed_time=None):
-        # """ Setup the header info for the report. """
+        """Create a summary of the outcomes of all given tests."""
 
         failures = errors = skips = success = 0
         for test in tests:
@@ -281,13 +282,8 @@ class HtmlTestResult(TextTestResult):
         }
         return header_info
 
-    @staticmethod
-    def _test_method_name(test_id):
-        """ Return a test name of the test id. """
-        return test_id.split('.')[-1]
-
-    def _report_tests(self, all_results, testRunner):
-        # """ Generate a html file for a given suite.  """
+    def _get_report_summaries(self, all_results, testRunner):
+        """ Generate headers and summaries for all given test cases."""
         start_time = testRunner.start_time
         elapsed_time = testRunner.time_taken.total_seconds()
 
@@ -306,11 +302,11 @@ class HtmlTestResult(TextTestResult):
         return header_info, summaries
 
     def generate_reports(self, testRunner):
-        """ Generate report for all given runned test object. """
+        """ Generate report(s) for all given test cases that have been run. """
         status_tags = ('success', 'danger', 'warning', 'info')
         all_results = self._get_info_by_testcase()
 
-        header_info, summaries = self._report_tests(all_results, testRunner)
+        header_info, summaries = self._get_report_summaries(all_results, testRunner)
 
         if not testRunner.combine_reports:
             for test_case_class_name, test_case_tests in all_results.items():

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
+
 import os
 import sys
 import time
+import copy
 import traceback
 from unittest import TestResult, TextTestResult
 from unittest.result import failfast
@@ -51,11 +53,11 @@ def strip_module_names(testcase_names):
     """Examine all given test case names and strip them the minimal
     names needed to distinguish each. This prevents cases where test
     cases housed in different files but with the same names cause clashes."""
-    result = testcase_names.copy()
+    result = copy.copy(testcase_names)
     for i, testcase in enumerate(testcase_names):
         classname = testcase.split(".")[-1]
         duplicate_found = False
-        testcase_names_ = testcase_names.copy()
+        testcase_names_ = copy.copy(testcase_names)
         del testcase_names_[i]
         for testcase_ in testcase_names_:
             classname_ = testcase_.split(".")[-1]

--- a/HtmlTestRunner/runner.py
+++ b/HtmlTestRunner/runner.py
@@ -37,6 +37,8 @@ class HTMLTestRunner(TextTestRunner):
         else:
             self.resultclass = resultclass
 
+        if template_args is not None and not isinstance(template_args, dict):
+            raise ValueError("template_args must be a dict-like.")
         self.template_args = template_args or {}
 
         self.report_title = report_title or "Unittest Results"

--- a/HtmlTestRunner/runner.py
+++ b/HtmlTestRunner/runner.py
@@ -13,9 +13,9 @@ class HTMLTestRunner(TextTestRunner):
 
     time_format = "%Y-%m-%d_%H-%M-%S"
 
-    def __init__(self, output=".", verbosity=2, stream=sys.stderr,
+    def __init__(self, output="./reports/", verbosity=2, stream=sys.stderr,
                  descriptions=True, failfast=False, buffer=False,
-                 report_title=None, template=None, resultclass=None,
+                 report_title=None, report_name=None, template=None, resultclass=None,
                  add_timestamp=True, open_in_browser=False,
                  combine_reports=False, template_args=None):
         self.verbosity = verbosity
@@ -40,6 +40,7 @@ class HTMLTestRunner(TextTestRunner):
         self.template_args = template_args or {}
 
         self.report_title = report_title or "Unittest Results"
+        self.report_name = report_name
         self.template = template
 
         self.open_in_browser = open_in_browser

--- a/HtmlTestRunner/runner.py
+++ b/HtmlTestRunner/runner.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 
 from unittest import TextTestRunner
-from .result import _HtmlTestResult
+from .result import HtmlTestResult
 
 UTF8 = "UTF-8"
 
@@ -11,9 +11,15 @@ UTF8 = "UTF-8"
 class HTMLTestRunner(TextTestRunner):
     """" A test runner class that output the results. """
 
-    def __init__(self, output, verbosity=2, stream=sys.stderr,
+    time_format = "%Y-%m-%d_%H-%M-%S"
+    start_time = None
+    time_taken = None
+
+    def __init__(self, output=".", verbosity=2, stream=sys.stderr,
                  descriptions=True, failfast=False, buffer=False,
-                 report_title=None, template=None, resultclass=None):
+                 report_title=None, template=None, resultclass=None,
+                 add_timestamp=True, open_in_browser=False,
+                 combine_reports=False, template_args=None):
         self.verbosity = verbosity
         self.output = output
         self.encoding = UTF8
@@ -21,21 +27,28 @@ class HTMLTestRunner(TextTestRunner):
         TextTestRunner.__init__(self, stream, descriptions, verbosity,
                                 failfast=failfast, buffer=buffer)
 
-        self.outsuffix = time.strftime("%Y-%m-%d_%H-%M-%S")
-        self.elapsed_times = True
+        if add_timestamp:
+            self.timestamp = time.strftime(self.time_format)
+        else:
+            self.timestamp = ""
+
         if resultclass is None:
-            self.resultclass = _HtmlTestResult
+            self.resultclass = HtmlTestResult
         else:
             self.resultclass = resultclass
 
-        self.report_title = report_title or "Test Result"
+        self.template_args = template_args or {}
+
+        self.report_title = report_title or "Unittest Results"
         self.template = template
+
+        self.open_in_browser = open_in_browser
+        self.combine_reports = combine_reports
 
     def _make_result(self):
         """ Create a TestResult object which will be used to store
         information about the executed tests. """
-        return self.resultclass(self.stream, self.descriptions, self.verbosity,
-                                self.elapsed_times)
+        return self.resultclass(self.stream, self.descriptions, self.verbosity)
 
     def run(self, test):
         """ Runs the given testcase or testsuite. """
@@ -93,6 +106,10 @@ class HTMLTestRunner(TextTestRunner):
             self.stream.writeln()
             self.stream.writeln('Generating HTML reports... ')
             result.generate_reports(self)
+            if self.open_in_browser:
+                import webbrowser
+                for report in result.report_files:
+                    webbrowser.open_new_tab('file://' + report)
         finally:
             pass
         return result

--- a/HtmlTestRunner/runner.py
+++ b/HtmlTestRunner/runner.py
@@ -12,8 +12,6 @@ class HTMLTestRunner(TextTestRunner):
     """" A test runner class that output the results. """
 
     time_format = "%Y-%m-%d_%H-%M-%S"
-    start_time = None
-    time_taken = None
 
     def __init__(self, output=".", verbosity=2, stream=sys.stderr,
                  descriptions=True, failfast=False, buffer=False,
@@ -46,6 +44,9 @@ class HTMLTestRunner(TextTestRunner):
 
         self.open_in_browser = open_in_browser
         self.combine_reports = combine_reports
+
+        self.start_time = 0
+        self.time_taken = 0
 
     def _make_result(self):
         """ Create a TestResult object which will be used to store
@@ -96,9 +97,9 @@ class HTMLTestRunner(TextTestRunner):
             if skipped:
                 infos.append("Skipped={}".format(skipped))
             if expectedFails:
-                infos.append("expected failures={}".format(expectedFails))
+                infos.append("Expected Failures={}".format(expectedFails))
             if unexpectedSuccesses:
-                infos.append("unexpected successes={}".format(unexpectedSuccesses))
+                infos.append("Unexpected Successes={}".format(unexpectedSuccesses))
 
             if infos:
                 self.stream.writeln(" ({})".format(", ".join(infos)))

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -12,8 +12,8 @@
             <div class="col-xs-12">
                 <h2 class="text-capitalize">{{ title }}</h2>
                 <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
-                <p class='attribute'><strong>Duration: </strong>{{ header_info.duration }}</p>
-                <p class='attribute'><strong>Summary: </strong>{{ header_info.status }}</p>
+                <p class='attribute'><strong>Duration: </strong>{{ header_info.status.duration }}</p>
+                <p class='attribute'><strong>Summary: </strong>Total: {{ header_info.status.total }}, Pass: {{ header_info.status.success }}{% if header_info.status.failure %}, Fail: {{ header_info.status.failure }}{% endif %}{% if header_info.status.error %}, Error: {{ header_info.status.error }}{% endif %}{% if header_info.status.skip %}, Skip: {{ header_info.status.skip }}{% endif %}</p>
             </div>
         </div>
         {% for test_case_name, tests_results in all_results.items() %}
@@ -60,7 +60,7 @@
                         {% endfor %}
                         <tr>
                             <td>
-                               {{ summaries[test_case_name] }}
+                                Total: {{ summaries[test_case_name].total }}, Pass: {{ summaries[test_case_name].success }}{% if summaries[test_case_name].failure %}, Fail: {{ summaries[test_case_name].failure }}{% endif %}{% if summaries[test_case_name].error %}, Error: {{ summaries[test_case_name].error }}{% endif %}{% if summaries[test_case_name].skip %}, Skip: {{ summaries[test_case_name].skip }}{% endif %} -- Duration: {{ summaries[test_case_name].duration }}
                             </td>
                         </tr>
                     </tbody>

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -30,7 +30,7 @@
                     <tbody>
                         {% for test_case in tests_results %}
                         <tr class='{{ status_tags[test_case.outcome] }}'>
-                            <td class="col-xs-9">{{ test_case.test_description }}</td>
+                            <td class="col-xs-9">{{ test_case.test_id.split(".")[-1] }}</td>
                             <td class="col-xs-3">
                                 <span class="label label-{{ status_tags[test_case.outcome] }}">
                                     {% if test_case.outcome == test_case.SUCCESS %}
@@ -43,12 +43,12 @@
                                         Error
                                     {% endif %}
                                 </span>
-                                {% if test_case.stdout or test_case.err %}
+                                {% if (test_case.stdout or test_case.err) and test_case.outcome != test_case.SKIP %}
                                     &nbsp<button class="btn btn-default btn-xs">View</button>
                                 {% endif %}
                             </td>
                         </tr>
-                        {% if test_case.stdout or test_case.err or test_case.err %}
+                        {% if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome != test_case.SKIP %}
                             <tr style="display:none;">
                                 <td class="col-xs-9">
                                     {% if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -16,8 +16,8 @@
                 <p class='attribute'><strong>Summary: </strong>Total: {{ header_info.status.total }}, Pass: {{ header_info.status.success }}{% if header_info.status.failure %}, Fail: {{ header_info.status.failure }}{% endif %}{% if header_info.status.error %}, Error: {{ header_info.status.error }}{% endif %}{% if header_info.status.skip %}, Skip: {{ header_info.status.skip }}{% endif %}</p>
             </div>
         </div>
-        {% for test_case_name, tests_results in all_results.items() %}
-        {% if tests_results %}
+        {%- for test_case_name, tests_results in all_results.items() %}
+        {%- if tests_results %}
         <div class="row">
             <div class="col-xs-12 col-sm-10 col-md-10">
                 <table class='table table-hover table-responsive'>
@@ -25,41 +25,111 @@
                         <tr>
                             <th>{{ test_case_name }}</th>
                             <th>Status</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for test_case in tests_results %}
+                        {%- for test_case in tests_results %}
+                        {%- if not test_case.subtests is defined %}
                         <tr class='{{ status_tags[test_case.outcome] }}'>
-                            <td class="col-xs-9">{{ test_case.test_id.split(".")[-1] }}</td>
-                            <td class="col-xs-3">
-                                <span class="label label-{{ status_tags[test_case.outcome] }}">
-                                    {% if test_case.outcome == test_case.SUCCESS %}
+                            <td class="col-xs-10">{{ test_case.test_id.split(".")[-1] }}</td>
+                            <td class="col-xs-1">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}" style="display:block;width:40px;">
+                                    {%- if test_case.outcome == test_case.SUCCESS -%}
                                         Pass
-                                    {% elif test_case.outcome == test_case.SKIP %}
+                                    {%- elif test_case.outcome == test_case.SKIP -%}
                                         Skip
-                                    {% elif test_case.outcome == test_case.FAILURE %}
+                                    {%- elif test_case.outcome == test_case.FAILURE -%}
                                         Fail
-                                    {% else %}
+                                    {%- else -%}
                                         Error
-                                    {% endif %}
+                                    {%- endif -%}
                                 </span>
-                                {% if (test_case.stdout or test_case.err) and test_case.outcome != test_case.SKIP %}
-                                    &nbsp<button class="btn btn-default btn-xs">View</button>
-                                {% endif %}
+                            </td>
+                            <td class="col-xs-1">
+                                {%- if (test_case.stdout or test_case.err) %}
+                                <button class="btn btn-default btn-xs">View</button>
+                                {%- endif %}
                             </td>
                         </tr>
-                        {% if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome != test_case.SKIP %}
-                            <tr style="display:none;">
-                                <td class="col-xs-9">
-                                    {% if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
-                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
-                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
-                                </td>
-                            </tr>
-                        {% endif %}
-                        {% endfor %}
+                        {%- if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome != test_case.SKIP %}
+                        <tr style="display:none;">
+                            <td class="col-xs-9" colspan="3">
+                                {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome == test_case.SKIP %}
+                        <tr style="display:none;">
+                            <td class="col-xs-9" colspan="3">
+                                {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err }}</p>{% endif %}
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- else %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-10">{{ test_case.test_id.split(".")[-1] }}</td>
+                            <td class="col-xs-1">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}" style="display:block;width:40px;">
+                                    {%- if test_case.outcome == test_case.SUCCESS -%}
+                                        Pass
+                                    {%- else -%}
+                                        Fail
+                                    {%- endif -%}
+                                </span>
+                            </td>
+                            <td class="col-xs-1">
+                                {%- if test_case.subtests %}
+                                <button class="btn btn-default btn-xs">View</button>
+                                {%- endif %}
+                            </td>
+                        </tr>
+                        {%- if test_case.subtests %}
+                        <tr style="display:none;">
+                            <td colspan="3">
+
+                                <table class='table table-hover table-responsive'>
+                                    <tbody>
+                                        {%- for subtest in test_case.subtests %}
+                                        <tr class='{{ status_tags[subtest.outcome] }}'>
+                                            <td class="col-xs-10">{{ subtest.test_id.split(".")[-1] }}</td>
+                                            <td class="col-xs-1">
+                                                <span class="label label-{{ status_tags[subtest.outcome] }}" style="display:block;width:40px;">
+                                                {%- if subtest.outcome == subtest.SUCCESS -%}
+                                                    Pass
+                                                {%- else -%}
+                                                    Fail
+                                                {%- endif -%}
+                                                </span>
+                                            </td>
+                                            <td class="col-xs-1">
+                                                {%- if subtest.stdout or subtest.err %}
+                                                <button class="btn btn-default btn-xs">View</button>
+                                                {%- endif %}
+                                            </td>
+                                        </tr>
+                                        {%- if subtest.stdout or subtest.err or subtest.err %}
+                                        <tr style="display:none;">
+                                            <td class="col-xs-9" colspan="3">
+                                                {%- if subtest.stdout %}<p>{{ subtest.stdout }}</p>{% endif %}
+                                                {%- if subtest.err %}<p style="color:maroon;">{{ subtest.err[0].__name__ }}: {{ subtest.err[1] }}</p>{% endif %}
+                                                {%- if subtest.err %}<p style="color:maroon;">{{ subtest.test_exception_info }}</p>{% endif %}
+                                            </td>
+                                        </tr>
+                                        {%- endif %}
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endfor %}
                         <tr>
-                            <td>
+                            <td colspan="3">
                                 Total: {{ summaries[test_case_name].total }}, Pass: {{ summaries[test_case_name].success }}{% if summaries[test_case_name].failure %}, Fail: {{ summaries[test_case_name].failure }}{% endif %}{% if summaries[test_case_name].error %}, Error: {{ summaries[test_case_name].error }}{% endif %}{% if summaries[test_case_name].skip %}, Skip: {{ summaries[test_case_name].skip }}{% endif %} -- Duration: {{ summaries[test_case_name].duration }}
                             </td>
                         </tr>
@@ -67,14 +137,15 @@
                 </table>
             </div>
         </div>
-        {% endif %}
-        {% endfor %}
+        {%- endif %}
+        {%- endfor %}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script type="text/javascript">
         $(document).ready(function(){
             $('td').on('click', '.btn', function(e){
                 e.preventDefault();
+                e.stopImmediatePropagation();
                 var $this = $(this);
                 var $nextRow = $this.closest('tr').next('tr');
                 $nextRow.slideToggle("fast");

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -106,15 +106,14 @@
                                                 </span>
                                             </td>
                                             <td class="col-xs-1">
-                                                {%- if subtest.stdout or subtest.err %}
+                                                {%- if subtest.err %}
                                                 <button class="btn btn-default btn-xs">View</button>
                                                 {%- endif %}
                                             </td>
                                         </tr>
-                                        {%- if subtest.stdout or subtest.err or subtest.err %}
+                                        {%- if subtest.err or subtest.err %}
                                         <tr style="display:none;">
                                             <td class="col-xs-9" colspan="3">
-                                                {%- if subtest.stdout %}<p>{{ subtest.stdout }}</p>{% endif %}
                                                 {%- if subtest.err %}<p style="color:maroon;">{{ subtest.err[0].__name__ }}: {{ subtest.err[1] }}</p>{% endif %}
                                                 {%- if subtest.err %}<p style="color:maroon;">{{ subtest.test_exception_info }}</p>{% endif %}
                                             </td>

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -57,7 +57,7 @@
                         {% endfor %}
                         <tr>
                             <td>
-                               Total Test Runned: {{total_test}}
+                               Total Tests Run: {{total_test}}
                             </td>
                             <td>
                                 <span>{{headers.status}}</span>

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{title}}</title>
+    <title>{{ title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
@@ -10,63 +10,65 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h2 class="text-capitalize">{{title}}</h2>
-                <p class='attribute'><strong>Start Time: </strong>{{headers.start_time}}</p>
-                <p class='attribute'><strong>Duration: </strong>{{headers.duration}}</p>
-                <p class='attribute'><strong>Status: </strong>{{headers.status}}</p>
+                <h2 class="text-capitalize">{{ title }}</h2>
+                <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
+                <p class='attribute'><strong>Duration: </strong>{{ header_info.duration }}</p>
+                <p class='attribute'><strong>Summary: </strong>{{ header_info.status }}</p>
             </div>
         </div>
+        {% for test_case_name, tests_results in all_results.items() %}
+        {% if tests_results %}
         <div class="row">
             <div class="col-xs-12 col-sm-10 col-md-10">
                 <table class='table table-hover table-responsive'>
                     <thead>
                         <tr>
-                            <th>{{testcase_name}}</th>
+                            <th>{{ test_case_name }}</th>
                             <th>Status</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for eachTestCase, status, errorType, errorMessage in tests_results %}
-                            <tr class='{{status}}'>
-                                <td class="col-xs-9">{{eachTestCase}}</td>
-                                <td class="col-xs-3">
-                                    <span class="label label-{{status}}">
-                                        {% if "success" == status %}
-                                            Pass
-                                        {% elif "info" == status %}
-                                            Skip
-                                        {% elif "danger" == status%}
-                                            Fail
-                                        {% else %}
-                                            Error
-                                        {% endif %}
-                                    </span>
-                                    {% if "success" not in status %}
-                                        &nbsp<button class="btn btn-default btn-xs">View</button>
+                        {% for test_case in tests_results %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-9">{{ test_case.test_description }}</td>
+                            <td class="col-xs-3">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}">
+                                    {% if test_case.outcome == test_case.SUCCESS %}
+                                        Pass
+                                    {% elif test_case.outcome == test_case.SKIP %}
+                                        Skip
+                                    {% elif test_case.outcome == test_case.FAILURE %}
+                                        Fail
+                                    {% else %}
+                                        Error
                                     {% endif %}
+                                </span>
+                                {% if test_case.stdout or test_case.err %}
+                                    &nbsp<button class="btn btn-default btn-xs">View</button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if test_case.stdout or test_case.err or test_case.err %}
+                            <tr style="display:none;">
+                                <td class="col-xs-9">
+                                    {% if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
                                 </td>
                             </tr>
-                            {% if "success" != status %}
-                                <tr style="display:none;">
-                                    <td class="col-xs-9">
-                                        <p>{{errorType}}</p>
-                                        <p>{{errorMessage}}</p>
-                                    </td> 
-                                </tr>
-                            {% endif %}
+                        {% endif %}
                         {% endfor %}
                         <tr>
                             <td>
-                               Total Tests Run: {{total_test}}
-                            </td>
-                            <td>
-                                <span>{{headers.status}}</span>
+                               {{ summaries[test_case_name] }}
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
+        {% endif %}
+        {% endfor %}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script type="text/javascript">

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Tests will be saved under a reports/ directory.
 `HtmlTestRunner` can also be used with `test suites`; just create a runner instance and call the run method with your suite. Here an example:
 
 ```python
-
 from unittest import TestLoader, TestSuite
 from HtmlTestRunner import HTMLTestRunner
 import ExampleTest
@@ -109,9 +108,18 @@ By default, separate reports will be produced for each `TestCase`.
 The `combine_reports` boolean kwarg can be used to tell `HTMLTestRunner` to instead produce a single report:
  ```python
 import HtmlTestRunner
-h = HtmlTestRunner.HTMLTestRunner(combine_reports=True)
+h = HtmlTestRunner.HTMLTestRunner(combine_reports=True).run(suite)
  ```
 
+### Setting a filename
+By default the name of the HTML file(s) produced will be created by joining the names of each test case together.
+The `report_name` kwarg can be used to specify a custom filename.
+For example, the following will produce a report file called "MyReport.html":
+
+```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(combine_reports=True, report_name="MyReport", add_timestamp=False).run(suite)
+```
 
 ## Console output:
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@
 
 
 
-HtmlTest runner is a unittest test runner that save test results
-in Html files, for human readable presentation of results.
+HtmlTest runner is a unittest test runner that saves results in a human-readable HTML format.
 
-This Package was inspired in ``unittest-xml-reporting`` and
-``HtmlTestRunner by tungwaiyip``.
-
-This project was created due to needs of getting human readables reports 
-for test runned, i found one but was lack and with a lot of bad practice,
-but i liked how ``xml-reporting`` works. So i create this one that 
-incorporated code from both projects but up to date.
+This Package was inspired by ``unittest-xml-reporting`` and
+``HtmlTestRunner by tungwaiyip`` and began by combining the methodology of the former with the functionality of the latter.
 
 ## Table of Content
 
@@ -33,114 +27,141 @@ incorporated code from both projects but up to date.
 To install HtmlTestRunner, run this command in your terminal:
 
 ```batch
-
-    $ pip install html-testRunner
+$ pip install html-testRunner
 ```
 
-This is the preferred method to install HtmlTestRunner, as it will always install the most recent stable release. If you don't have [pip](https://pip.pypa.io) installed, this [Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/) can guide
+This is the preferred method to install HtmlTestRunner, as it will always install the most recent stable release.
+If you don't have [pip](https://pip.pypa.io) installed, this [Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/) can guide
 you through the process.
 
 
 ## Usage:
 
-```python
-
-    import HtmlTestRunner
-    import unittest
-
-
-    class TestStringMethods(unittest.TestCase):
-        """ Example test for HtmlRunner. """
-
-        def test_upper(self):
-            self.assertEqual('foo'.upper(), 'FOO')
-
-        def test_isupper(self):
-            self.assertTrue('FOO'.isupper())
-            self.assertFalse('Foo'.isupper())
-
-        def test_split(self):
-            s = 'hello world'
-            self.assertEqual(s.split(), ['hello', 'world'])
-            # check that s.split fails when the separator is not a string
-            with self.assertRaises(TypeError):
-                s.split(2)
-
-        def test_error(self):
-            """ This test should be marked as error one. """
-            raise ValueError
-
-        def test_fail(self):
-            """ This test should fail. """
-            self.assertEqual(1, 2)
-
-        @unittest.skip("This is a skipped test.")
-        def test_skip(self):
-            """ This test should be skipped. """
-            pass
-
-    if __name__ == '__main__':
-        unittest.main(testRunner=HtmlTestRunner.HTMLTestRunner(output='example_dir'))
-```
-
-Just import `HtmlTestRunner` from package, then pass it to `unittest.main` with the `testRunner` keyword. This class have only one required parameter, with is `output` this is use to place the report of the TestCase, this is saved under a reports directory.
-
-
-For does who have `test suites` it works too, just create a runner instance and call the run method with your suite. Here an example:
+### With unittest.main()
 
 ```python
 
-    from unittest import TestLoader, TestSuite
-    from HtmlTestRunner import HTMLTestRunner
-    import ExampleTest
-    import Example2Test
+import HtmlTestRunner
+import unittest
 
-    example_tests = TestLoader().loadTestsFromTestCase(ExampleTests)
-    example2_tests = TestLoader().loadTestsFromTestCase(Example2Test)
 
-    suite = TestSuite([example_tests, example2_tests])
+class TestStringMethods(unittest.TestCase):
+    """ Example test for HtmlRunner. """
 
-    runner = HTMLTestRunner(output='example_suite')
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
 
-    runner.run(suite)
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
+
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+    def test_error(self):
+        """ This test should be marked as error one. """
+        raise ValueError
+
+    def test_fail(self):
+        """ This test should fail. """
+        self.assertEqual(1, 2)
+
+    @unittest.skip("This is a skipped test.")
+    def test_skip(self):
+        """ This test should be skipped. """
+        pass
+
+if __name__ == '__main__':
+    unittest.main(testRunner=HtmlTestRunner.HTMLTestRunner())
+```
+
+Just import `HtmlTestRunner` from package, then pass it to `unittest.main` with the `testRunner` keyword.
+Tests will be saved under a reports/ directory.
+
+### With Test Suites
+`HtmlTestRunner` can also be used with `test suites`; just create a runner instance and call the run method with your suite. Here an example:
+
+```python
+
+from unittest import TestLoader, TestSuite
+from HtmlTestRunner import HTMLTestRunner
+import ExampleTest
+import Example2Test
+
+example_tests = TestLoader().loadTestsFromTestCase(ExampleTest)
+example2_tests = TestLoader().loadTestsFromTestCase(Example2Test)
+
+suite = TestSuite([example_tests, example2_tests])
+
+runner = HTMLTestRunner(output='example_suite')
+
+runner.run(suite)
 
 ```
+
+### Combining Reports into a Single Report
+
+By default, separate reports will be produced for each `TestCase`.
+The `combine_reports` boolean kwarg can be used to tell `HTMLTestRunner` to instead produce a single report:
+ ```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(combine_reports=True)
+ ```
 
 
 ## Console output:
 
 ![Console output](docs/console_output.png)
 
-This is an example of what you got in the console.
+This is an example of the console output expected when using `HTMLTestRunner`.
 
 
 ## Test Result:
 
 ![Test Results](docs/test_results.gif)
 
-This is a sample of the results from the template that came by default with the runner. If you want to use your own template you can pass the abolute path to it when instanciating the `HtmlTestRunner` class, like `HtmlTestRunner(output='example_suite', template='path/to/template', report_title='My Report'`.
-Your template must use jinja2 syntax, since this is the engine we use.
+This is a sample of the results from the template that came by default with the runner.
+
+## Custom Templates:
+
+If you want to use your own template you can pass the absolute path when instantiating the `HTMLTestRunner` class using the `template` kwarg:
+ ```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(template='path/to/template')
+ ```
+Your template must use `jinja2` syntax, since this is the engine we use.
 
 
-`report_title` is the title we want to appear at the top of the report. When using a custom template, these values are pass.
+When using any template, the following variables will be available by default for use by `jinja2`:
 
-
-- `title`: This is the report name
+- `title`: This is the report title - by default this is "Unittests Results" but can be changed using the `report_title` kwarg
 - `headers`: This is a dict with 3 items:
-    - `start_time`: When the test was run.
-    - `duration`: How much it took to run
-    - `status`: a string with how much test pass, fail, throw an error or were skip.
-    Note: Remenber on jinja templetes dict can be access throw dot notation, e.g: `{{headers.status}}`
-- `testcase_name`: The name of the Testcase class.
-- `tests_results`: A list of lists, each inner list contains 4 elements, in the following order:
-    - Test description or test name: If test does not have docs string, test name is used.
-    - Status: Could be one of ('success', 'danger', 'warning', 'info')
-    - Error type
-    - Error message
-- `total_tests`: The amount of tests run
+    - `start_time`: A `datetime` object representing when the test was run
+    - `duration`: A string showing how long all tests took to run in either seconds or milliseconds
+    - `status`: A string containing a brief summary of all tests
+- `all_results`: A dict - keys are the names of each test case and values are lists containing test result objects (see the source code or the template for what information these provide)
+- `summaries`: A dict - keys are the names of each test case and values are strings containing a brief summary of a given test case
+
+Furthermore, you can provide any number of further variables to access from the template using the `template_args` kwarg.
+For example, if you wanted to have the name of the logged in user available to insert into reports that could be achieved as follows:
+```python
+import getpass
+import HtmlTestRunner
+
+template_args = {
+    "user": getpass.getuser()
+}
+h = HtmlTestRunner.HTMLTestRunner(template='path/to/template', template_args=template_args)
+```
+
+Now the user name can be accessed from a template using `{{ user }}`.
 
 
-You can access these values a vars, for rendering just surround it with `{{ var }}`, for `tests_results` you need to iterate it. Click [here](docs/example_template.html) for a template example, this is the default one shipped with the package.
+Click [here](docs/example_template.html) for a template example, this is the default one shipped with the package.
 
 
 

--- a/README.md
+++ b/README.md
@@ -139,13 +139,18 @@ Your template must use `jinja2` syntax, since this is the engine we use.
 When using any template, the following variables will be available by default for use by `jinja2`:
 
 - `title`: This is the report title - by default this is "Unittests Results" but can be changed using the `report_title` kwarg
-- `headers`: This is a dict with 3 items:
+- `headers`: This is a dict with 2 items:
     - `start_time`: A `datetime` object representing when the test was run
-    - `duration`: A string showing how long all tests took to run in either seconds or milliseconds
-    - `status`: A string containing a brief summary of all tests
+    - `status`: A dict of of the same form as the sub-dicts described below for `summaries` but for all tests combined
 - `all_results`: A dict - keys are the names of each test case and values are lists containing test result objects (see the source code or the template for what information these provide)
-- `summaries`: A dict - keys are the names of each test case and values are strings containing a brief summary of a given test case
-
+- `summaries`: A dict - keys are the names of each test case and values are dicts containing:
+    - `total`: The total number of tests
+    - `success`: The number of passed tests
+    - `failure`: The number of failed tests
+    - `error`: The number of errored tests
+    - `skip`: The number of skipped tests
+    - `duration`: A string showing how long all these tests took to run in either seconds or milliseconds
+    
 Furthermore, you can provide any number of further variables to access from the template using the `template_args` kwarg.
 For example, if you wanted to have the name of the logged in user available to insert into reports that could be achieved as follows:
 ```python
@@ -158,7 +163,7 @@ template_args = {
 h = HtmlTestRunner.HTMLTestRunner(template='path/to/template', template_args=template_args)
 ```
 
-Now the user name can be accessed from a template using `{{ user }}`.
+Now the user name can be accessed from a template using `jinja2` syntax: `{{ user }}`.
 
 
 Click [here](docs/example_template.html) for a template example, this is the default one shipped with the package.
@@ -172,7 +177,7 @@ Click [here](docs/example_template.html) for a template example, this is the def
 - [x] Add custom templates
 - [ ] Add xml results
 - [ ] Add support for Python2.7
-- [ ] Add support for one report when running test suites.
+- [x] Add support for one report when running test suites.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ if __name__ == '__main__':
 ```
 
 Just import `HtmlTestRunner` from package, then pass it to `unittest.main` with the `testRunner` keyword.
-Tests will be saved under a reports/ directory.
+Tests will be saved under a reports/ directory by default (the `output` kwarg controls this.).
 
 ### With Test Suites
-`HtmlTestRunner` can also be used with `test suites`; just create a runner instance and call the run method with your suite. Here an example:
+`HtmlTestRunner` can also be used with `test suites`; just create a runner instance and call the run method with your suite.
+Here an example:
 
 ```python
 from unittest import TestLoader, TestSuite
@@ -99,7 +100,6 @@ suite = TestSuite([example_tests, example2_tests])
 runner = HTMLTestRunner(output='example_suite')
 
 runner.run(suite)
-
 ```
 
 ### Combining Reports into a Single Report

--- a/docs/example_template.html
+++ b/docs/example_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{title}}</title>
+    <title>{{ title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
@@ -10,63 +10,65 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h2 class="text-capitalize">{{title}}</h2>
-                <p class='attribute'><strong>Start Time: </strong>{{headers.start_time}}</p>
-                <p class='attribute'><strong>Duration: </strong>{{headers.duration}}</p>
-                <p class='attribute'><strong>Status: </strong>{{headers.status}}</p>
+                <h2 class="text-capitalize">{{ title }}</h2>
+                <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
+                <p class='attribute'><strong>Duration: </strong>{{ header_info.duration }}</p>
+                <p class='attribute'><strong>Summary: </strong>{{ header_info.status }}</p>
             </div>
         </div>
+        {% for test_case_name, tests_results in all_results.items() %}
+        {% if tests_results %}
         <div class="row">
             <div class="col-xs-12 col-sm-10 col-md-10">
                 <table class='table table-hover table-responsive'>
                     <thead>
                         <tr>
-                            <th>{{testcase_name}}</th>
+                            <th>{{ test_case_name }}</th>
                             <th>Status</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for eachTestCase, status, errorType, errorMessage in tests_results %}
-                            <tr class='{{status}}'>
-                                <td class="col-xs-9">{{eachTestCase}}</td>
-                                <td class="col-xs-3">
-                                    <span class="label label-{{status}}">
-                                        {% if "success" == status %}
-                                            Pass
-                                        {% elif "info" == status %}
-                                            Skip
-                                        {% elif "danger" == status%}
-                                            Fail
-                                        {% else %}
-                                            Error
-                                        {% endif %}
-                                    </span>
-                                    {% if "success" not in status %}
-                                        &nbsp<button class="btn btn-default btn-xs">View</button>
+                        {% for test_case in tests_results %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-9">{{ test_case.test_description }}</td>
+                            <td class="col-xs-3">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}">
+                                    {% if test_case.outcome == test_case.SUCCESS %}
+                                        Pass
+                                    {% elif test_case.outcome == test_case.SKIP %}
+                                        Skip
+                                    {% elif test_case.outcome == test_case.FAILURE %}
+                                        Fail
+                                    {% else %}
+                                        Error
                                     {% endif %}
+                                </span>
+                                {% if test_case.stdout or test_case.err %}
+                                    &nbsp<button class="btn btn-default btn-xs">View</button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if test_case.stdout or test_case.err or test_case.err %}
+                            <tr style="display:none;">
+                                <td class="col-xs-9">
+                                    {% if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
                                 </td>
                             </tr>
-                            {% if "success" != status %}
-                                <tr style="display:none;">
-                                    <td class="col-xs-9">
-                                        <p>{{errorType}}</p>
-                                        <p>{{errorMessage}}</p>
-                                    </td> 
-                                </tr>
-                            {% endif %}
+                        {% endif %}
                         {% endfor %}
                         <tr>
                             <td>
-                               Total Test Runned: {{total_test}}
-                            </td>
-                            <td>
-                                <span>{{headers.status}}</span>
+                               {{ summaries[test_case_name] }}
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
+        {% endif %}
+        {% endfor %}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script type="text/javascript">

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,49 @@
+import HtmlTestRunner
+import unittest
+
+
+class TestStringMethods(unittest.TestCase):
+    """ Example test for HtmlRunner. """
+
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
+
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
+
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+    def test_error(self):
+        """ This test should be marked as error one. """
+        raise ValueError
+
+    def test_fail(self):
+        """ This test should fail. """
+        self.assertEqual(1, 2)
+
+    @unittest.skip("This is a skipped test.")
+    def test_skip(self):
+        """ This test should be skipped. """
+        pass
+
+
+class MoreTests(unittest.TestCase):
+    def test_1(self):
+        print("This is different to test2.MoreTests.test_1")
+        self.assertAlmostEqual(1, 1.1, delta=0.05)
+
+
+if __name__ == '__main__':
+    unittest.main(
+        testRunner=HtmlTestRunner.HTMLTestRunner(
+            open_in_browser=True,
+            combine_reports=True,
+            template_args={}
+        )
+    )

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,11 +32,21 @@ class TestStringMethods(unittest.TestCase):
         """ This test should be skipped. """
         pass
 
+    def test_subs(self):
+        test_string = "test1"
+        for i, char in enumerate(test_string):
+            with self.subTest(i=i):
+                self.assertEqual(char, "1")
+
+        with self.subTest(test_string=test_string):
+            # subtests that error will appear as a failure presently
+            raise AttributeError
+
 
 class MoreTests(unittest.TestCase):
     def test_1(self):
         print("This is different to test2.MoreTests.test_1")
-        self.assertAlmostEqual(1, 1.1, delta=0.05)
+        self.assertEqual(100, -100)
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,7 +32,7 @@ class TestStringMethods(unittest.TestCase):
         """ This test should be skipped. """
         pass
 
-    def test_subs(self):
+    def test_subs_fail(self):
         test_string = "test1"
         for i, char in enumerate(test_string):
             with self.subTest(i=i):

--- a/tests/test2.py
+++ b/tests/test2.py
@@ -44,18 +44,22 @@ if __name__ == '__main__':
     more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
     suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
 
-    HTMLTestRunner(report_title='TEST COMBINED',
-                   report_name="MyReports",
-                   add_timestamp=False,
-                   open_in_browser=True,
-                   combine_reports=True).run(suite)
+    HTMLTestRunner(
+        report_title='TEST COMBINED',
+        report_name="MyReports",
+        add_timestamp=False,
+        open_in_browser=True,
+        combine_reports=True
+    ).run(suite)
 
     tests = unittest.TestLoader().loadTestsFromTestCase(My_Tests)
     other_tests = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)
     more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
     more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
     suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
-    HTMLTestRunner(report_title='TEST SEPARATE',
-                   report_name="MyReports",
-                   open_in_browser=True,
-                   combine_reports=False).run(suite)
+    HTMLTestRunner(
+        report_title='TEST SEPARATE',
+        report_name="MyReports",
+        open_in_browser=True,
+        combine_reports=False
+    ).run(suite)

--- a/tests/test2.py
+++ b/tests/test2.py
@@ -1,0 +1,61 @@
+import unittest
+
+from HtmlTestRunner import HTMLTestRunner
+
+from test import TestStringMethods
+from test import MoreTests as MoreTests_
+
+
+class My_Tests(unittest.TestCase):
+
+    def test_one(self):
+        self.assertTrue(True)
+
+    def test_two(self):
+        # demonstrate that stdout is captured in passing tests
+        print("HOLA CARACOLA")
+        self.assertTrue(True)
+
+    def test_three(self):
+        self.assertTrue(True)
+
+    def test_1(self):
+        # demonstrate that stdout is captured in failing tests
+        print("HELLO")
+        self.assertTrue(False)
+
+    def test_2(self):
+        self.assertTrue(False)
+
+    def test_3(self):
+        self.assertTrue(False)
+
+
+class MoreTests(unittest.TestCase):
+    def test_1(self):
+        print("This is different to test.MoreTests.test_1")
+        self.assertAlmostEqual(1, 1.1, delta=0.05)
+
+
+if __name__ == '__main__':
+    tests = unittest.TestLoader().loadTestsFromTestCase(My_Tests)
+    other_tests = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)
+    more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
+    more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
+    suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
+
+    HTMLTestRunner(report_title='TEST COMBINED',
+                   report_name="MyReports",
+                   add_timestamp=False,
+                   open_in_browser=True,
+                   combine_reports=True).run(suite)
+
+    tests = unittest.TestLoader().loadTestsFromTestCase(My_Tests)
+    other_tests = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)
+    more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
+    more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
+    suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
+    HTMLTestRunner(report_title='TEST SEPARATE',
+                   report_name="MyReports",
+                   open_in_browser=True,
+                   combine_reports=False).run(suite)

--- a/tests/test2.py
+++ b/tests/test2.py
@@ -30,6 +30,12 @@ class My_Tests(unittest.TestCase):
     def test_3(self):
         self.assertTrue(False)
 
+    def test_z_subs_pass(self):
+        for i in range(2):
+            with self.subTest(i=i):
+                print("i = {}".format(i))  # this won't appear for now
+                self.assertEqual(i, i)
+
 
 class MoreTests(unittest.TestCase):
     def test_1(self):
@@ -43,7 +49,6 @@ if __name__ == '__main__':
     more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
     more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
     suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
-
     HTMLTestRunner(
         report_title='TEST COMBINED',
         report_name="MyReports",


### PR DESCRIPTION
I have added some new functionality to `HtmlTestRunner` that you will hopefully find useful.

- reports can be combined by setting the `HTMLTestRunner` `combine_reports` kwarg to `True`: this will produce a single file containing a separate table for each TestCase. (#6)
- the `output` argument is now optional and defaults to a folder called reports under the current working directory (`"./reports/"`) (#12 I think)
- the user can pass extra variables to templates using the `template_args` kwarg in the form of a dict (see readme for an example of its use)
- filename timestamps are optional using the `add_timestamp` kwarg
- any stdout from a test method will be available in the expanded view for that test method in a report (#27 I think)
- traceback details are also available in the report (#28)
- template formatting has changed
- readme has been expanded and some of the wording changed
- option added to have reports automatically open in new browser tab using the `open_in_browser` kwarg
- TestCases with underscores in name are supported (#29)

EDIT: More features have been added as I've gone (see below). This started too big and has only gotten bigger so sorry about that.