### PR TITLE
New functionality (combine reports etc) (#32)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,4 +8,4 @@
 
 ## Contributors
 
-None yet. Why not be the first?
+* James Sloan <james.m.t.sloan@gmail.com>

--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{title}}</title>
+    <title>{{ title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
@@ -10,69 +10,141 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h2 class="text-capitalize">{{title}}</h2>
-                <p class='attribute'><strong>Start Time: </strong>{{headers.start_time}}</p>
-                <p class='attribute'><strong>Duration: </strong>{{headers.duration}}</p>
-                <p class='attribute'><strong>Status: </strong>{{headers.status}}</p>
+                <h2 class="text-capitalize">{{ title }}</h2>
+                <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
+                <p class='attribute'><strong>Duration: </strong>{{ header_info.status.duration }}</p>
+                <p class='attribute'><strong>Summary: </strong>Total: {{ header_info.status.total }}, Pass: {{ header_info.status.success }}{% if header_info.status.failure %}, Fail: {{ header_info.status.failure }}{% endif %}{% if header_info.status.error %}, Error: {{ header_info.status.error }}{% endif %}{% if header_info.status.skip %}, Skip: {{ header_info.status.skip }}{% endif %}</p>
             </div>
         </div>
+        {%- for test_case_name, tests_results in all_results.items() %}
+        {%- if tests_results %}
         <div class="row">
             <div class="col-xs-12 col-sm-10 col-md-10">
                 <table class='table table-hover table-responsive'>
                     <thead>
                         <tr>
-                            <th>{{testcase_name}}</th>
+                            <th>{{ test_case_name }}</th>
                             <th>Status</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for eachTestCase, status, errorType, errorMessage in tests_results %}
-                            <tr class='{{status}}'>
-                                <td class="col-xs-9">{{eachTestCase}}</td>
-                                <td class="col-xs-3">
-                                    <span class="label label-{{status}}">
-                                        {% if "success" == status %}
-                                            Pass
-                                        {% elif "info" == status %}
-                                            Skip
-                                        {% elif "danger" == status%}
-                                            Fail
-                                        {% else %}
-                                            Error
-                                        {% endif %}
-                                    </span>
-                                    {% if "success" not in status %}
-                                        &nbsp<button class="btn btn-default btn-xs">View</button>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            {% if "success" != status %}
-                                <tr style="display:none;">
-                                    <td class="col-xs-9">
-                                        <p>{{errorType}}</p>
-                                        <p>{{errorMessage}}</p>
-                                    </td> 
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                        <tr>
-                            <td>
-                               Total Test Runned: {{total_test}}
+                        {%- for test_case in tests_results %}
+                        {%- if not test_case.subtests is defined %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-10">{{ test_case.test_id.split(".")[-1] }}</td>
+                            <td class="col-xs-1">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}" style="display:block;width:40px;">
+                                    {%- if test_case.outcome == test_case.SUCCESS -%}
+                                        Pass
+                                    {%- elif test_case.outcome == test_case.SKIP -%}
+                                        Skip
+                                    {%- elif test_case.outcome == test_case.FAILURE -%}
+                                        Fail
+                                    {%- else -%}
+                                        Error
+                                    {%- endif -%}
+                                </span>
                             </td>
-                            <td>
-                                <span>{{headers.status}}</span>
+                            <td class="col-xs-1">
+                                {%- if (test_case.stdout or test_case.err) %}
+                                <button class="btn btn-default btn-xs">View</button>
+                                {%- endif %}
+                            </td>
+                        </tr>
+                        {%- if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome != test_case.SKIP %}
+                        <tr style="display:none;">
+                            <td class="col-xs-9" colspan="3">
+                                {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome == test_case.SKIP %}
+                        <tr style="display:none;">
+                            <td class="col-xs-9" colspan="3">
+                                {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err }}</p>{% endif %}
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- else %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-10">{{ test_case.test_id.split(".")[-1] }}</td>
+                            <td class="col-xs-1">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}" style="display:block;width:40px;">
+                                    {%- if test_case.outcome == test_case.SUCCESS -%}
+                                        Pass
+                                    {%- else -%}
+                                        Fail
+                                    {%- endif -%}
+                                </span>
+                            </td>
+                            <td class="col-xs-1">
+                                {%- if test_case.subtests %}
+                                <button class="btn btn-default btn-xs">View</button>
+                                {%- endif %}
+                            </td>
+                        </tr>
+                        {%- if test_case.subtests %}
+                        <tr style="display:none;">
+                            <td colspan="3">
+
+                                <table class='table table-hover table-responsive'>
+                                    <tbody>
+                                        {%- for subtest in test_case.subtests %}
+                                        <tr class='{{ status_tags[subtest.outcome] }}'>
+                                            <td class="col-xs-10">{{ subtest.test_id.split(".")[-1] }}</td>
+                                            <td class="col-xs-1">
+                                                <span class="label label-{{ status_tags[subtest.outcome] }}" style="display:block;width:40px;">
+                                                {%- if subtest.outcome == subtest.SUCCESS -%}
+                                                    Pass
+                                                {%- else -%}
+                                                    Fail
+                                                {%- endif -%}
+                                                </span>
+                                            </td>
+                                            <td class="col-xs-1">
+                                                {%- if subtest.err %}
+                                                <button class="btn btn-default btn-xs">View</button>
+                                                {%- endif %}
+                                            </td>
+                                        </tr>
+                                        {%- if subtest.err or subtest.err %}
+                                        <tr style="display:none;">
+                                            <td class="col-xs-9" colspan="3">
+                                                {%- if subtest.err %}<p style="color:maroon;">{{ subtest.err[0].__name__ }}: {{ subtest.err[1] }}</p>{% endif %}
+                                                {%- if subtest.err %}<p style="color:maroon;">{{ subtest.test_exception_info }}</p>{% endif %}
+                                            </td>
+                                        </tr>
+                                        {%- endif %}
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        {%- endif %}
+                        {%- endif %}
+                        {%- endfor %}
+                        <tr>
+                            <td colspan="3">
+                                Total: {{ summaries[test_case_name].total }}, Pass: {{ summaries[test_case_name].success }}{% if summaries[test_case_name].failure %}, Fail: {{ summaries[test_case_name].failure }}{% endif %}{% if summaries[test_case_name].error %}, Error: {{ summaries[test_case_name].error }}{% endif %}{% if summaries[test_case_name].skip %}, Skip: {{ summaries[test_case_name].skip }}{% endif %} -- Duration: {{ summaries[test_case_name].duration }}
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
+        {%- endif %}
+        {%- endfor %}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script type="text/javascript">
         $(document).ready(function(){
             $('td').on('click', '.btn', function(e){
                 e.preventDefault();
+                e.stopImmediatePropagation();
                 var $this = $(this);
                 var $nextRow = $this.closest('tr').next('tr');
                 $nextRow.slideToggle("fast");

--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@
 
 
 
-HtmlTest runner is a unittest test runner that save test results
-in Html files, for human readable presentation of results.
+HtmlTest runner is a unittest test runner that saves results in a human-readable HTML format.
 
-This Package was inspired in ``unittest-xml-reporting`` and
-``HtmlTestRunner by tungwaiyip``.
-
-This project was created due to needs of getting human readables reports 
-for test runned, i found one but was lack and with a lot of bad practice,
-but i liked how ``xml-reporting`` works. So i create this one that 
-incorporated code from both projects but up to date.
+This Package was inspired by ``unittest-xml-reporting`` and
+``HtmlTestRunner by tungwaiyip`` and began by combining the methodology of the former with the functionality of the latter.
 
 ## Table of Content
 
@@ -33,114 +27,154 @@ incorporated code from both projects but up to date.
 To install HtmlTestRunner, run this command in your terminal:
 
 ```batch
-
-    $ pip install html-testRunner
+$ pip install html-testRunner
 ```
 
-This is the preferred method to install HtmlTestRunner, as it will always install the most recent stable release. If you don't have [pip](https://pip.pypa.io) installed, this [Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/) can guide
+This is the preferred method to install HtmlTestRunner, as it will always install the most recent stable release.
+If you don't have [pip](https://pip.pypa.io) installed, this [Python installation guide](http://docs.python-guide.org/en/latest/starting/installation/) can guide
 you through the process.
 
 
 ## Usage:
 
-```python
-
-    import HtmlTestRunner
-    import unittest
-
-
-    class TestStringMethods(unittest.TestCase):
-        """ Example test for HtmlRunner. """
-
-        def test_upper(self):
-            self.assertEqual('foo'.upper(), 'FOO')
-
-        def test_isupper(self):
-            self.assertTrue('FOO'.isupper())
-            self.assertFalse('Foo'.isupper())
-
-        def test_split(self):
-            s = 'hello world'
-            self.assertEqual(s.split(), ['hello', 'world'])
-            # check that s.split fails when the separator is not a string
-            with self.assertRaises(TypeError):
-                s.split(2)
-
-        def test_error(self):
-            """ This test should be marked as error one. """
-            raise ValueError
-
-        def test_fail(self):
-            """ This test should fail. """
-            self.assertEqual(1, 2)
-
-        @unittest.skip("This is a skipped test.")
-        def test_skip(self):
-            """ This test should be skipped. """
-            pass
-
-    if __name__ == '__main__':
-        unittest.main(testRunner=HtmlTestRunner.HTMLTestRunner(output='example_dir'))
-```
-
-Just import `HtmlTestRunner` from package, then pass it to `unittest.main` with the `testRunner` keyword. This class have only one required parameter, with is `output` this is use to place the report of the TestCase, this is saved under a reports directory.
-
-
-For does who have `test suites` it works too, just create a runner instance and call the run method with your suite. Here an example:
+### With unittest.main()
 
 ```python
 
-    from unittest import TestLoader, TestSuite
-    from HtmlTestRunner import HTMLTestRunner
-    import ExampleTest
-    import Example2Test
+import HtmlTestRunner
+import unittest
 
-    example_tests = TestLoader().loadTestsFromTestCase(ExampleTests)
-    example2_tests = TestLoader().loadTestsFromTestCase(Example2Test)
 
-    suite = TestSuite([example_tests, example2_tests])
+class TestStringMethods(unittest.TestCase):
+    """ Example test for HtmlRunner. """
 
-    runner = HTMLTestRunner(output='example_suite')
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
 
-    runner.run(suite)
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
 
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+    def test_error(self):
+        """ This test should be marked as error one. """
+        raise ValueError
+
+    def test_fail(self):
+        """ This test should fail. """
+        self.assertEqual(1, 2)
+
+    @unittest.skip("This is a skipped test.")
+    def test_skip(self):
+        """ This test should be skipped. """
+        pass
+
+if __name__ == '__main__':
+    unittest.main(testRunner=HtmlTestRunner.HTMLTestRunner())
 ```
 
+Just import `HtmlTestRunner` from package, then pass it to `unittest.main` with the `testRunner` keyword.
+Tests will be saved under a reports/ directory by default (the `output` kwarg controls this.).
+
+### With Test Suites
+`HtmlTestRunner` can also be used with `test suites`; just create a runner instance and call the run method with your suite.
+Here an example:
+
+```python
+from unittest import TestLoader, TestSuite
+from HtmlTestRunner import HTMLTestRunner
+import ExampleTest
+import Example2Test
+
+example_tests = TestLoader().loadTestsFromTestCase(ExampleTest)
+example2_tests = TestLoader().loadTestsFromTestCase(Example2Test)
+
+suite = TestSuite([example_tests, example2_tests])
+
+runner = HTMLTestRunner(output='example_suite')
+
+runner.run(suite)
+```
+
+### Combining Reports into a Single Report
+
+By default, separate reports will be produced for each `TestCase`.
+The `combine_reports` boolean kwarg can be used to tell `HTMLTestRunner` to instead produce a single report:
+ ```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(combine_reports=True).run(suite)
+ ```
+
+### Setting a filename
+By default the name of the HTML file(s) produced will be created by joining the names of each test case together.
+The `report_name` kwarg can be used to specify a custom filename.
+For example, the following will produce a report file called "MyReport.html":
+
+```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(combine_reports=True, report_name="MyReport", add_timestamp=False).run(suite)
+```
 
 ## Console output:
 
 ![Console output](docs/console_output.png)
 
-This is an example of what you got in the console.
+This is an example of the console output expected when using `HTMLTestRunner`.
 
 
 ## Test Result:
 
 ![Test Results](docs/test_results.gif)
 
-This is a sample of the results from the template that came by default with the runner. If you want to use your own template you can pass the abolute path to it when instanciating the `HtmlTestRunner` class, like `HtmlTestRunner(output='example_suite', template='path/to/template', report_title='My Report'`.
-Your template must use jinja2 syntax, since this is the engine we use.
+This is a sample of the results from the template that came by default with the runner.
+
+## Custom Templates:
+
+If you want to use your own template you can pass the absolute path when instantiating the `HTMLTestRunner` class using the `template` kwarg:
+ ```python
+import HtmlTestRunner
+h = HtmlTestRunner.HTMLTestRunner(template='path/to/template')
+ ```
+Your template must use `jinja2` syntax, since this is the engine we use.
 
 
-`report_title` is the title we want to appear at the top of the report. When using a custom template, these values are pass.
+When using any template, the following variables will be available by default for use by `jinja2`:
+
+- `title`: This is the report title - by default this is "Unittests Results" but can be changed using the `report_title` kwarg
+- `headers`: This is a dict with 2 items:
+    - `start_time`: A `datetime` object representing when the test was run
+    - `status`: A dict of of the same form as the sub-dicts described below for `summaries` but for all tests combined
+- `all_results`: A dict - keys are the names of each test case and values are lists containing test result objects (see the source code or the template for what information these provide)
+- `summaries`: A dict - keys are the names of each test case and values are dicts containing:
+    - `total`: The total number of tests
+    - `success`: The number of passed tests
+    - `failure`: The number of failed tests
+    - `error`: The number of errored tests
+    - `skip`: The number of skipped tests
+    - `duration`: A string showing how long all these tests took to run in either seconds or milliseconds
+    
+Furthermore, you can provide any number of further variables to access from the template using the `template_args` kwarg.
+For example, if you wanted to have the name of the logged in user available to insert into reports that could be achieved as follows:
+```python
+import getpass
+import HtmlTestRunner
+
+template_args = {
+    "user": getpass.getuser()
+}
+h = HtmlTestRunner.HTMLTestRunner(template='path/to/template', template_args=template_args)
+```
+
+Now the user name can be accessed from a template using `jinja2` syntax: `{{ user }}`.
 
 
-- `title`: This is the report name
-- `headers`: This is a dict with 3 items:
-    - `start_time`: When the test was run.
-    - `duration`: How much it took to run
-    - `status`: a string with how much test pass, fail, throw an error or were skip.
-    Note: Remenber on jinja templetes dict can be access throw dot notation, e.g: `{{headers.status}}`
-- `testcase_name`: The name of the Testcase class.
-- `tests_results`: A list of lists, each inner list contains 4 elements, in the following order:
-    - Test description or test name: If test does not have docs string, test name is used.
-    - Status: Could be one of ('success', 'danger', 'warning', 'info')
-    - Error type
-    - Error message
-- `total_tests`: The amount of tests run
-
-
-You can access these values a vars, for rendering just surround it with `{{ var }}`, for `tests_results` you need to iterate it. Click [here](docs/example_template.html) for a template example, this is the default one shipped with the package.
+Click [here](docs/example_template.html) for a template example, this is the default one shipped with the package.
 
 
 
@@ -151,7 +185,7 @@ You can access these values a vars, for rendering just surround it with `{{ var 
 - [x] Add custom templates
 - [ ] Add xml results
 - [ ] Add support for Python2.7
-- [ ] Add support for one report when running test suites.
+- [x] Add support for one report when running test suites.
 
 ## Contributing
 

--- a/docs/example_template.html
+++ b/docs/example_template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{title}}</title>
+    <title>{{ title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
@@ -10,63 +10,65 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                <h2 class="text-capitalize">{{title}}</h2>
-                <p class='attribute'><strong>Start Time: </strong>{{headers.start_time}}</p>
-                <p class='attribute'><strong>Duration: </strong>{{headers.duration}}</p>
-                <p class='attribute'><strong>Status: </strong>{{headers.status}}</p>
+                <h2 class="text-capitalize">{{ title }}</h2>
+                <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
+                <p class='attribute'><strong>Duration: </strong>{{ header_info.duration }}</p>
+                <p class='attribute'><strong>Summary: </strong>{{ header_info.status }}</p>
             </div>
         </div>
+        {% for test_case_name, tests_results in all_results.items() %}
+        {% if tests_results %}
         <div class="row">
             <div class="col-xs-12 col-sm-10 col-md-10">
                 <table class='table table-hover table-responsive'>
                     <thead>
                         <tr>
-                            <th>{{testcase_name}}</th>
+                            <th>{{ test_case_name }}</th>
                             <th>Status</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for eachTestCase, status, errorType, errorMessage in tests_results %}
-                            <tr class='{{status}}'>
-                                <td class="col-xs-9">{{eachTestCase}}</td>
-                                <td class="col-xs-3">
-                                    <span class="label label-{{status}}">
-                                        {% if "success" == status %}
-                                            Pass
-                                        {% elif "info" == status %}
-                                            Skip
-                                        {% elif "danger" == status%}
-                                            Fail
-                                        {% else %}
-                                            Error
-                                        {% endif %}
-                                    </span>
-                                    {% if "success" not in status %}
-                                        &nbsp<button class="btn btn-default btn-xs">View</button>
+                        {% for test_case in tests_results %}
+                        <tr class='{{ status_tags[test_case.outcome] }}'>
+                            <td class="col-xs-9">{{ test_case.test_description }}</td>
+                            <td class="col-xs-3">
+                                <span class="label label-{{ status_tags[test_case.outcome] }}">
+                                    {% if test_case.outcome == test_case.SUCCESS %}
+                                        Pass
+                                    {% elif test_case.outcome == test_case.SKIP %}
+                                        Skip
+                                    {% elif test_case.outcome == test_case.FAILURE %}
+                                        Fail
+                                    {% else %}
+                                        Error
                                     {% endif %}
+                                </span>
+                                {% if test_case.stdout or test_case.err %}
+                                    &nbsp<button class="btn btn-default btn-xs">View</button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if test_case.stdout or test_case.err or test_case.err %}
+                            <tr style="display:none;">
+                                <td class="col-xs-9">
+                                    {% if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
+                                    {% if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
                                 </td>
                             </tr>
-                            {% if "success" != status %}
-                                <tr style="display:none;">
-                                    <td class="col-xs-9">
-                                        <p>{{errorType}}</p>
-                                        <p>{{errorMessage}}</p>
-                                    </td> 
-                                </tr>
-                            {% endif %}
+                        {% endif %}
                         {% endfor %}
                         <tr>
                             <td>
-                               Total Test Runned: {{total_test}}
-                            </td>
-                            <td>
-                                <span>{{headers.status}}</span>
+                               {{ summaries[test_case_name] }}
                             </td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
+        {% endif %}
+        {% endfor %}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script type="text/javascript">

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,59 @@
+import HtmlTestRunner
+import unittest
+
+
+class TestStringMethods(unittest.TestCase):
+    """ Example test for HtmlRunner. """
+
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
+
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
+
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+    def test_error(self):
+        """ This test should be marked as error one. """
+        raise ValueError
+
+    def test_fail(self):
+        """ This test should fail. """
+        self.assertEqual(1, 2)
+
+    @unittest.skip("This is a skipped test.")
+    def test_skip(self):
+        """ This test should be skipped. """
+        pass
+
+    def test_subs_fail(self):
+        test_string = "test1"
+        for i, char in enumerate(test_string):
+            with self.subTest(i=i):
+                self.assertEqual(char, "1")
+
+        with self.subTest(test_string=test_string):
+            # subtests that error will appear as a failure presently
+            raise AttributeError
+
+
+class MoreTests(unittest.TestCase):
+    def test_1(self):
+        print("This is different to test2.MoreTests.test_1")
+        self.assertEqual(100, -100)
+
+
+if __name__ == '__main__':
+    unittest.main(
+        testRunner=HtmlTestRunner.HTMLTestRunner(
+            open_in_browser=True,
+            combine_reports=True,
+            template_args={}
+        )
+    )

--- a/tests/test2.py
+++ b/tests/test2.py
@@ -1,0 +1,70 @@
+import unittest
+
+from HtmlTestRunner import HTMLTestRunner
+
+from test import TestStringMethods
+from test import MoreTests as MoreTests_
+
+
+class My_Tests(unittest.TestCase):
+
+    def test_one(self):
+        self.assertTrue(True)
+
+    def test_two(self):
+        # demonstrate that stdout is captured in passing tests
+        print("HOLA CARACOLA")
+        self.assertTrue(True)
+
+    def test_three(self):
+        self.assertTrue(True)
+
+    def test_1(self):
+        # demonstrate that stdout is captured in failing tests
+        print("HELLO")
+        self.assertTrue(False)
+
+    def test_2(self):
+        self.assertTrue(False)
+
+    def test_3(self):
+        self.assertTrue(False)
+
+    def test_z_subs_pass(self):
+        for i in range(2):
+            with self.subTest(i=i):
+                print("i = {}".format(i))  # this won't appear for now
+                self.assertEqual(i, i)
+
+
+class MoreTests(unittest.TestCase):
+    def test_1(self):
+        print("This is different to test.MoreTests.test_1")
+        self.assertAlmostEqual(1, 1.1, delta=0.05)
+
+
+if __name__ == '__main__':
+    tests = unittest.TestLoader().loadTestsFromTestCase(My_Tests)
+    other_tests = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)
+    more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
+    more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
+    suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
+    HTMLTestRunner(
+        report_title='TEST COMBINED',
+        report_name="MyReports",
+        add_timestamp=False,
+        open_in_browser=True,
+        combine_reports=True
+    ).run(suite)
+
+    tests = unittest.TestLoader().loadTestsFromTestCase(My_Tests)
+    other_tests = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)
+    more_tests = unittest.TestLoader().loadTestsFromTestCase(MoreTests)
+    more_tests_ = unittest.TestLoader().loadTestsFromTestCase(MoreTests_)
+    suite = unittest.TestSuite([tests, other_tests, more_tests, more_tests_])
+    HTMLTestRunner(
+        report_title='TEST SEPARATE',
+        report_name="MyReports",
+        open_in_browser=True,
+        combine_reports=False
+    ).run(suite)


### PR DESCRIPTION
* Fixed Template Wording

* added following functionality:
- support for combining reports into single report (combine_reports kwarg)
- support for test cases with underscores in name
- optional timestamping of filenames (add_timestamp kwarg)
- optional automatic opening of generated reports in browser tab (paths to reports are returned from test result) (open_in_browser kwarg)
- support for optional user variables to be passed to jinja2 template (template_args kwarg)
- added tracebacks to reports
- added stdout to reports (so tests that pass can also be expanded
- print relative paths to generated reports
- made default output directory the current working directory so there are now no required args

also:
- updated and adjusted readme
- changed use of deprecated _TextTestResult -> TextTestResult
- changed format of template slightly

* - expanded test case names to include full path to classes (should avoid clashes from duplicate names)
- simplified test method names

* updated docstrings and deleted unused method

* added check for template_args to be dict-like

* changed how summaries are passed to templates: using a dict instead of a string to allow the user to customise their template more easily.
also some other small tweaks.

* updated readme to reflect changes to template variables

* added optional report naming
reduced prepended paths to testcase names except for when common testcase names need to be distinguished

* added report_name usage to README

* added a couple of tests showing use with unittest.main() and constructing test suites, including case where name collision between similarly named test cases is handled. combined reports and separate reports are shown.

* re-imposed alphabetical ordering of unittest in how tests appear in reports.

* added support for subtests
added support for skipped tests skip reasons
changed template to support subtests in sub-tables
fixed bug where non-combined tests had summaries with details from all tests
tweaked format of HTML has that info buttons line up better

* fixed bug where subtests that all passed were duplicated with an extra stub in the report. this needed some rather ugly filtering but unittest seems to insist on calling addSuccess() in this case
removed support for std.out in subtests for now as this was being accumulated across subtests

* updated authors list

* Updated results.py to use the copy library so that it can be run usin… (#2)

* Updated results.py to use the copy library so that it can be run using Python 2.7

* changed import order