### PR TITLE
Current Running Tests can be seen at start rather than at end

### DIFF
--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -175,6 +175,7 @@ class HtmlTestResult(TextTestResult):
         if self.showAll:
             self.stream.write(" " + self.getDescription(test))
             self.stream.write(" ... ")
+            self.stream.flush()
 
     def _save_output_data(self):
         try:


### PR DESCRIPTION
Before we would only know which test was running after it was complete as it printed the time taken  as well.
I wanted to see the current running tests so I just flushed that part of the statement out before the time instead of together