### PR TITLE
use "pre" tag to make the error message look friendlier

### DIFF
--- a/HtmlTestRunner/template/report_template.html
+++ b/HtmlTestRunner/template/report_template.html
@@ -55,9 +55,9 @@
                         {%- if (test_case.stdout or test_case.err or test_case.err) and test_case.outcome != test_case.SKIP %}
                         <tr style="display:none;">
                             <td class="col-xs-9" colspan="3">
-                                {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
-                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
-                                {%- if test_case.err %}<p style="color:maroon;">{{ test_case.test_exception_info }}</p>{% endif %}
+                                {%- if test_case.stdout %}<pre>{{ test_case.stdout }}</pre>{% endif %}
+                                {%- if test_case.err %}<pre style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</pre>{% endif %}
+                                {%- if test_case.err %}<pre style="color:maroon;">{{ test_case.test_exception_info }}</pre>{% endif %}
                             </td>
                         </tr>
                         {%- endif %}


### PR DESCRIPTION
Hi Ordanis,
I'm a HtmlTestRunner user, I find the error messages don't look very friendly in HTML, So I made some changes to make it look a little bit better, Consider that only the Template file was modified, I don't think we need a test. 

### Results the following：

**Before**:
![before](https://user-images.githubusercontent.com/7058240/98801972-91ac4500-244d-11eb-9b37-f79602c9eb0f.jpg)

**After**:
![after](https://user-images.githubusercontent.com/7058240/98801983-940e9f00-244d-11eb-8951-8a067ac82d90.jpg)
