### PR TITLE
fix UnicodeEncodeError occured when reports generated with special chars

### DIFF
--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -400,7 +400,7 @@ class HtmlTestResult(TextTestResult):
         path_file = os.path.abspath(os.path.join(dir_to, report_name))
         self.stream.writeln(os.path.relpath(path_file))
         self.report_files.append(path_file)
-        with open(path_file, 'w') as report_file:
+        with open(path_file, 'w', encoding='utf-8') as report_file:
             report_file.write(report)
 
     def _exc_info_to_string(self, err, test):


### PR DESCRIPTION
adding encoding='utf-8' in generate_file() in result.py on line 403 to fix issue below:

Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\HtmlTestRunner\runner.py", line 112, in run
    result.generate_reports(self)
  File "C:\Python37\lib\site-packages\HtmlTestRunner\result.py", line 388, in generate_reports
    self.generate_file(testRunner, report_name_body, html_file)
  File "C:\Python37\lib\site-packages\HtmlTestRunner\result.py", line 404, in generate_file
    report_file.write(report)
  File "C:\Python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 68858-68859: character maps to <undefined>

Also see an issue in github about the same - https://github.com/oldani/HtmlTestRunner/issues/48